### PR TITLE
fix: remove locale-string quoting in pfb heading

### DIFF
--- a/pfb.sh
+++ b/pfb.sh
@@ -931,7 +931,7 @@ EOF
             fi
             echo
             icon="${3:-§}"
-            message=$"${BOLD}${message}
+            message="${BOLD}${message}
 "
             _print_message
             ;;


### PR DESCRIPTION
## Summary

- Removes `$"..."` (locale-based/gettext quoting) from the `heading` case handler
- Replaces with plain `"..."`, consistent with every other string in `pfb.sh`

## Detail

`$"..."` triggers locale-based translation (gettext), which is never the intent and behaves differently across shells and locales. This is a portability bug — POSIX does not define `$"..."`.

Closes #11

## Test plan

- [ ] `pfb heading "Test heading"` renders correctly
- [ ] `pfb heading "Test heading" "🚀"` renders correctly with icon
- [ ] Run `source ./pfb.sh && pfb test` — headings section shows no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)