### PR TITLE
fix: stop active spinner before pfb info and pfb warn

### DIFF
--- a/pfb.sh
+++ b/pfb.sh
@@ -854,6 +854,7 @@ EOF
                 echo "Example: pfb info \"Processing complete\"" >&2
                 return 1
             fi
+            _wait_stop
             level="${INFO_COLOR}[info] "
             message="${message}
 "
@@ -866,6 +867,7 @@ EOF
                 echo "Example: pfb warn \"Low disk space detected\"" >&2
                 return 1
             fi
+            _wait_stop
             level="${WARN_COLOR}[warn] "
             message="${message}
 "


### PR DESCRIPTION
## Summary

- Adds `_wait_stop` to the `info` and `warn` case handlers
- Makes all four log-level commands (`info`, `warn`, `err`, `success`) consistent: they each stop any active spinner before rendering

## Detail

`pfb err` and `pfb success` already called `_wait_stop` before rendering. `pfb info` and `pfb warn` did not, so they wrote over the spinner line producing overlapping output.

Closes #10

## Test plan

- [ ] Start a spinner, then call `pfb info "message"` — spinner stops cleanly, info appears on its own line
- [ ] Start a spinner, then call `pfb warn "message"` — spinner stops cleanly, warning appears on its own line
- [ ] Run `source ./pfb.sh && pfb test` — log levels and spinner sections show no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)