### PR TITLE
fix: restore cursor on abnormal exit from select and confirm

### DIFF
--- a/pfb.sh
+++ b/pfb.sh
@@ -181,7 +181,7 @@ pfb() {
         for (( i=0; i<${#options[@]}; i++ )); do echo >&2; done
         last_row="$(get_cursor_row)"
         start_row=$((last_row - ${#options[@]}))
-        trap "cursor_on >&2; stty echo; printf '\n' >&2; exit" 2
+        trap "cursor_on >&2; stty echo; printf '\n' >&2; exit" EXIT INT TERM HUP
         cursor_off >&2
         selected=0
 
@@ -268,7 +268,7 @@ pfb() {
             esac
         }
 
-        trap "cursor_on >&2; stty echo; printf '\n' >&2; exit" 2
+        trap "cursor_on >&2; stty echo; printf '\n' >&2; exit" EXIT INT TERM HUP
 
         # Hint reflects the default (what Enter will do), not the current highlight
         local hint


### PR DESCRIPTION
## Summary

- Extends the `trap` in `_select` from `INT` (signal 2) only to `EXIT INT TERM HUP`
- Applies the same fix to `_confirm`, which has the identical pattern

## Detail

`pfb select` hides the cursor at the start of the selection loop and only restored it on clean exit. The trap previously only caught `SIGINT` (Ctrl-C). If the script was killed with `SIGTERM`, `SIGHUP`, or errored mid-selection, the cursor remained invisible until the user ran `reset` or `tput cnorm`.

`EXIT` fires on all shell exits (including errors), ensuring the cursor is always restored.

Closes #12

## Test plan

- [ ] Run `pfb select` and press Ctrl-C — cursor restored immediately
- [ ] Run `pfb select ... &` then `kill %1` — cursor restored in parent terminal
- [ ] Run `source ./pfb.sh && pfb test` — selection and confirm sections show no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)