### PR TITLE
feat: add pfb test to Quick Start examples in --help

### DIFF
--- a/pfb.sh
+++ b/pfb.sh
@@ -734,6 +734,7 @@ pfb() {
  Usage: pfb <command> [args...]
 
  Quick Start Examples:
+   pfb test                                    # Live demo of all features
    pfb info "Starting process..."              # Display info message
    pfb spinner start "Loading..." 'sleep 2'   # Show spinner during command
    pfb confirm "Continue?" && next_step        # Ask yes/no question


### PR DESCRIPTION
## Summary

- Adds `pfb test` as the first entry in the Quick Start Examples section of `pfb --help`

## Detail

`pfb test` is the best way for a new user to explore the library — it demos every feature with live animation. It was previously only visible in the "All Commands" list, which most new users won't read first.

Closes #14

## Test plan

- [ ] `pfb --help` shows `pfb test` as the first Quick Start example

🤖 Generated with [Claude Code](https://claude.com/claude-code)