### PR TITLE
feat: add Bash 4.0+ version check at source time

### DIFF
--- a/pfb.sh
+++ b/pfb.sh
@@ -15,6 +15,13 @@ export PFB_SPINNER_PID=""
 export PFB_SPINNER_FLAG=""
 export PFB_SPINNER_ROW=""
 
+# Require Bash 4.0+ for nameref support (local -n) used in _get_spinner_frames
+if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+    printf "pfb: requires Bash 4.0 or later (current: %s)\n" "$BASH_VERSION" >&2
+    printf "On macOS: brew install bash\n" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
 # ---------------------------------------------------------------------------
 # ANSI/VT100 color and style variables
 # Set once at source time. Use PFB_FORCE_COLOR=1 before sourcing to force


### PR DESCRIPTION
## Summary

- Adds a version guard immediately after the variable exports, before any function definitions
- Emits a clear, actionable error message with a macOS `brew install bash` hint
- Uses `return 1 2>/dev/null || exit 1` to avoid killing an interactive shell session

## Detail

`pfb` uses `local -n` (nameref) in `_get_spinner_frames`, which requires Bash 4.0+. On macOS the system Bash is 3.2 (shipped since 2007), so sourcing `pfb.sh` would silently succeed but then fail with a cryptic `local: -n: invalid option` when the spinner was first used. The version check surfaces this clearly at source time.

Closes #13

## Test plan

- [ ] On Bash 4+: `source ./pfb.sh` succeeds silently as before
- [ ] On Bash 3.2 (or `bash --version` spoofed): clear error message and `brew install bash` hint printed to stderr, source returns non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)