### PR TITLE
feat: add PFB_SPINNER_LABEL to customise spinner prefix

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "MD013": { "line_length": 120, "tables": false, "code_blocks": false },
+  "MD024": { "siblings_only": true },
+  "MD033": false
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,7 +152,7 @@ for the string `[done]` will need to update to `[success]`.
 ### Backward Compatibility
 
 | Old pattern | Status | Migration |
-|---|---|---|
+| --- | --- | --- |
 | `pfb select ...; idx=$?` | Deprecated | `idx=$(pfb select ...)` |
 | `pfb select-from ...` | Preserved (exit-code alias) | Migrate to `pfb select` |
 | `pfb wait <msg> [cmd]` | Preserved | `pfb spinner start` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,36 +4,46 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-pfb (pretty feedback for bash) is a lightweight, dependency-free Bash library that provides terminal UI components and feedback mechanisms for shell scripts. The entire library is contained in a single `pfb.sh` file that can be sourced into any Bash script.
+pfb (pretty feedback for bash) is a lightweight, dependency-free Bash library that provides terminal UI components and
+feedback mechanisms for shell scripts. The entire library is contained in a single `pfb.sh` file that can be sourced
+into any Bash script.
 
 ## Core Architecture
 
 ### Single-File Design
+
 The entire library exists in `pfb.sh`. This file must:
+
 - Be sourceable with `source pfb.sh`
 - Work on bash 4.0+ with zero dependencies
 - Be completely self-contained (no external binaries except standard UNIX utilities)
 
 ### Key Design Patterns
 
-**ANSI/VT100 Terminal Control**: All visual output uses ANSI escape sequences defined in `_pfb_set_ansi_vars()`, called once at source time. The library provides cursor control, color management, and screen manipulation primitives.
+**ANSI/VT100 Terminal Control**: All visual output uses ANSI escape sequences defined in `_pfb_set_ansi_vars()`, called
+once at source time. The library provides cursor control, color management, and screen manipulation primitives.
 
-**Function Namespace**: All internal functions are prefixed with `_` (e.g., `_wait_start`, `_print_message`). The public API is accessed via the main `pfb()` function which routes to internal implementations based on the first argument.
+**Function Namespace**: All internal functions are prefixed with `_` (e.g., `_wait_start`, `_print_message`). The public
+API is accessed via the main `pfb()` function which routes to internal implementations based on the first argument.
 
-**Spinner Management**: Background spinner processes use a flag file (`/tmp/pfb_spinner_$$_${RANDOM}`) for synchronization. The spinner PID and flag path are stored in `PFB_SPINNER_PID` and `PFB_SPINNER_FLAG`. The `_wait_stop()` function MUST be synchronous to prevent race conditions.
+**Spinner Management**: Background spinner processes use a flag file (`/tmp/pfb_spinner_$$_${RANDOM}`) for
+synchronization. The spinner PID and flag path are stored in `PFB_SPINNER_PID` and `PFB_SPINNER_FLAG`. The
+`_wait_stop()` function MUST be synchronous to prevent race conditions.
 
-**Cursor Position Save/Restore**: The prompt/answer pattern uses `save_pos()` and `restore_pos()` to maintain cursor position across multi-step interactions. This is critical for inline feedback.
+**Cursor Position Save/Restore**: The prompt/answer pattern uses `save_pos()` and `restore_pos()` to maintain cursor
+position across multi-step interactions. This is critical for inline feedback.
 
 ## Configuration
 
 Environment variables controlling behaviour (set before sourcing pfb.sh):
+
 - `PFB_SPINNER_STYLE` (default: 2) — Spinner animation style (0-17)
 - `PFB_DEFAULT_LOG_DIR` (default: `$HOME/logs`) — Command log directory
 - `PFB_DEFAULT_LOG` (default: "scripts") — Log file basename
 - `PFB_NON_INTERACTIVE` (default: unset) — Set to `1` to auto-answer prompts (CI/cron)
 - `PFB_FORCE_COLOR` (default: unset) — Force colors even when stdout is not a TTY
 - `PFB_NO_COLOR` (default: 0) — Set to `1` to disable colors
-- `NO_COLOR` (default: unset) — Standard color-disable flag (https://no-color.org)
+- `NO_COLOR` (default: unset) — Standard color-disable flag (<https://no-color.org>)
 
 ## Public API Commands
 
@@ -46,7 +56,8 @@ Access all functionality via: `pfb <command> [args...]`
 **Prompt pattern**: `prompt`, `answer`
 **Utilities**: `test`, `list-spinner-styles`, `logfile`
 
-**Backward compatibility**: The old commands (`wait`, `wait-stop`, `select-from`) continue to work as redirects to the new API.
+**Backward compatibility**: The old commands (`wait`, `wait-stop`, `select-from`) continue to work as redirects to the
+new API.
 
 ## Testing and Development
 
@@ -65,6 +76,7 @@ cd examples
 ```
 
 **VHS tapes** in `examples/` directory:
+
 - All tapes source `config.tape` for consistent styling
 - Each tape corresponds to a feature demo (e.g., `spinner.tape` → `spinner.gif`)
 - The `run_vhs.sh` script skips `config.tape` when generating all
@@ -85,11 +97,13 @@ ffmpeg -y -i file.gif -vf "select=eq(n\,$((count * 95 / 100))),scale=1024:-1" \
 **Basic colors**: 8 ANSI colors available as foreground (`BLACK`, `RED`, etc.) and background (`BBLACK`, `BRED`, etc.)
 
 **RGB colors**: Use `rgb_fg(r, g, b)` and `rgb_bg(r, g, b)` for 24-bit color:
+
 ```bash
 printf "$(rgb_fg 215 119 87)Orange text${RESET}\n"
 ```
 
 **Semantic colors**: Pre-defined RGB colors for consistency:
+
 - `INFO_COLOR` - Soft blue-cyan (100, 180, 220)
 - `WARN_COLOR` - Warm amber (255, 180, 80)
 - `ERROR_COLOR` - Clear red (240, 90, 90)
@@ -101,7 +115,9 @@ Always use `${RESET}` to clear formatting.
 
 ## Key Implementation Details
 
-**Spinner cleanup**: The spinner background process cleanup in `_wait_stop()` (called by `pfb spinner stop`) follows this sequence:
+**Spinner cleanup**: The spinner background process cleanup in `_wait_stop()` (called by `pfb spinner stop`) follows
+this sequence:
+
 1. Remove flag file to signal stop
 2. Wait up to 0.5s for graceful exit
 3. Force kill if still running
@@ -122,6 +138,7 @@ and wipe `ESC=""`, corrupting all cursor sequences.
 ## Cursor Control Functions
 
 Low-level cursor control is available for custom UI:
+
 - `cursor_on`, `cursor_off` - Visibility
 - `get_cursor_row`, `get_cursor_col` - Position queries
 - `cursor_to row [col]`, `cursor_up`, `cursor_down`, `cursor_sol` - Movement
@@ -130,7 +147,8 @@ Low-level cursor control is available for custom UI:
 
 ## Logging
 
-Commands run via `pfb spinner start "message" command` are logged to `$PFB_DEFAULT_LOG_DIR/$PFB_DEFAULT_LOG.log` with command and output.
+Commands run via `pfb spinner start "message" command` are logged to `$PFB_DEFAULT_LOG_DIR/$PFB_DEFAULT_LOG.log`
+with command and output.
 
 ## Compatibility Notes
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ pfb can be configured using environment variables:
 | Variable | Default | Description |
 | :------- | :------ | :---------- |
 | `PFB_SPINNER_STYLE` | `2` | Spinner style (0-17). Run `pfb test` to see all styles |
+| `PFB_SPINNER_LABEL` | `wait` | Spinner prefix label. Set to empty string to suppress the prefix |
 | `PFB_DEFAULT_LOG_DIR` | `$HOME/logs` | Directory where command logs are stored |
 | `PFB_DEFAULT_LOG` | `scripts` | Base name for log files (creates `$PFB_DEFAULT_LOG.log`) |
 | `PFB_NON_INTERACTIVE` | (unset) | Set to `1` to auto-answer prompts with defaults (CI, cron, scripts) |
@@ -81,6 +82,17 @@ You can also start a spinner manually and stop it later:
 ```bash
 pfb spinner start message
 pfb spinner stop
+```
+
+The prefix label defaults to `[wait]`. Use `PFB_SPINNER_LABEL` to customise it or set it to
+empty to suppress the prefix entirely:
+
+```bash
+PFB_SPINNER_LABEL="deploy" pfb spinner start "Deploying to production..." deploy.sh
+# [deploy] ⣾ Deploying to production...
+
+PFB_SPINNER_LABEL="" pfb spinner start "Downloading..." 'curl ...'
+# ⣾ Downloading...
 ```
 
 This is usefully followed up with a pfb success log level message or a pfb answer message.
@@ -159,7 +171,8 @@ The pfb answer message can be used to put a formatted answer after the prompt me
 
 `pfb answer message`
 
-This pattern saves the cursor position after the prompt and restores it when displaying the answer, keeping everything on one line. For simple text input, use `pfb input` instead.
+This pattern saves the cursor position after the prompt and restores it when displaying the answer, keeping everything on
+one line. For simple text input, use `pfb input` instead.
 
 ## Helper functions and variables
 
@@ -227,7 +240,8 @@ Examples using RGB color functions:
 
 ## Comparison with gum
 
-[gum](https://github.com/charmbracelet/gum) is a more comprehensive TUI toolkit that offers similar functionality with additional components like file browsers, tables, pagers, and advanced text filtering.
+[gum](https://github.com/charmbracelet/gum) is a more comprehensive TUI toolkit that offers similar functionality with
+additional components like file browsers, tables, pagers, and advanced text filtering.
 
 **When to use pfb:**
 
@@ -244,4 +258,5 @@ Examples using RGB color functions:
 - Prefer standalone binaries over sourced libraries
 - Want extensive styling options via CLI flags
 
-pfb occupies the lightweight, dependency-free niche - ideal for scripts you distribute or run in constrained environments where installing external tools adds friction.
+pfb occupies the lightweight, dependency-free niche — ideal for scripts you distribute or run in constrained
+environments where installing external tools adds friction.

--- a/pfb.sh
+++ b/pfb.sh
@@ -11,6 +11,7 @@ export PFB_VERSION="2.1.0"
 export PFB_DEFAULT_LOG_DIR="${HOME}/logs"
 export PFB_DEFAULT_LOG="scripts"
 export PFB_SPINNER_STYLE="2"
+export PFB_SPINNER_LABEL="wait"
 export PFB_SPINNER_PID=""
 export PFB_SPINNER_FLAG=""
 export PFB_SPINNER_ROW=""
@@ -461,13 +462,15 @@ pfb() {
             local start="$start_seconds"
             local row="$PFB_SPINNER_ROW"
             local step=0
+            local label_pfx=""
+            [[ -n "${PFB_SPINNER_LABEL}" ]] && label_pfx="${BOLD}${INFO_COLOR}[${PFB_SPINNER_LABEL}]${RESET} "
             while [[ -f "$flag_file" ]]; do
                 local elapsed=$(( SECONDS - start ))
                 local elapsed_str=""
                 [[ $elapsed -ge 3 ]] && elapsed_str=" ${DIM}${elapsed}s${RESET}"
                 cursor_to "$row"
                 erase_line
-                printf "${BOLD}${INFO_COLOR}[wait]${RESET} ${BOLD}${SPINNER_COLOR}${frames[step++ % ${#frames[@]}]}${RESET} ${message}${RESET}${elapsed_str}"
+                printf "${label_pfx}${BOLD}${SPINNER_COLOR}${frames[step++ % ${#frames[@]}]}${RESET} ${message}${RESET}${elapsed_str}"
                 sleep 0.08
             done
             # Clean up on exit
@@ -776,6 +779,7 @@ pfb() {
 
  Environment Variables:
    PFB_SPINNER_STYLE      Spinner animation style (0-17, default: 2)
+   PFB_SPINNER_LABEL      Spinner prefix label (default: wait, empty = no prefix)
    PFB_DEFAULT_LOG_DIR    Log directory (default: $HOME/logs)
    PFB_DEFAULT_LOG        Log basename (default: scripts)
    PFB_NON_INTERACTIVE    Set to 1 to auto-answer prompts (CI/non-TTY)


### PR DESCRIPTION
## Summary

- Exports `PFB_SPINNER_LABEL="wait"` (preserves all existing behaviour)
- Spinner prefix is now driven by `PFB_SPINNER_LABEL` — set to a custom string or empty string to suppress the prefix entirely
- Documents the variable in `pfb --help`

## Usage

```bash
# Default — unchanged
pfb spinner start "Loading..." 'sleep 2'
# [wait] ⣾ Loading...

# Custom label
PFB_SPINNER_LABEL="deploy" pfb spinner start "Deploying to production..." deploy.sh
# [deploy] ⣾ Deploying to production...

# No prefix
PFB_SPINNER_LABEL="" pfb spinner start "Downloading..." 'curl ...'
# ⣾ Downloading...
```

Closes #9

## Test plan

- [ ] Default (`PFB_SPINNER_LABEL="wait"`) — output unchanged
- [ ] `PFB_SPINNER_LABEL="install"` — shows `[install]` prefix
- [ ] `PFB_SPINNER_LABEL=""` — no prefix, spinner glyph and message only
- [ ] `pfb --help` — shows `PFB_SPINNER_LABEL` in Environment Variables section

🤖 Generated with [Claude Code](https://claude.com/claude-code)