### PR TITLE
ci: automate Homebrew formula update on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Homebrew formula
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          TARBALL_URL="https://github.com/ali5ter/pfb/archive/refs/tags/${GITHUB_REF_NAME}.tar.gz"
+          SHA256=$(curl -sL "$TARBALL_URL" | sha256sum | awk '{print $1}')
+
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/ali5ter/homebrew-tap.git" tap
+          cd tap
+
+          sed -i \
+            -e "s|url \".*\"|url \"${TARBALL_URL}\"|" \
+            -e "s|sha256 \".*\"|sha256 \"${SHA256}\"|" \
+            Formula/pfb.rb
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/pfb.rb
+          git commit -m "pfb ${GITHUB_REF_NAME}"
+          git push


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` triggered on `v*` tag pushes
- Computes SHA256 of the GitHub-generated source tarball for the new tag
- Clones `ali5ter/homebrew-tap` via `HOMEBREW_TAP_TOKEN` and patches `Formula/pfb.rb` with the updated version and sha256
- Commits and pushes the formula update automatically — no manual edits needed after a release

## Prerequisite

Before merging, add the `HOMEBREW_TAP_TOKEN` secret to this repo:

```bash
gh secret set HOMEBREW_TAP_TOKEN --repo ali5ter/pfb
```

The PAT (`homebrew-tap-writer`) already exists in your GitHub account.

## Test plan

- [ ] Add `HOMEBREW_TAP_TOKEN` secret to the pfb repo
- [ ] Merge this PR
- [ ] Push a `v*` tag and verify the Actions workflow runs successfully
- [ ] Confirm `Formula/pfb.rb` in `ali5ter/homebrew-tap` is updated with the correct version and sha256

Closes #27

🤖 Generated with [claude-workflow-skills:triage](https://github.com/ali5ter/claude-workflow-skills) on behalf of [Alister](https://github.com/ali5ter)