### PR TITLE
fix: recover spinner state across separate process invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to pfb are documented here.
 
+## [Unreleased]
+
+### Fixes
+
+- **Spinner stop across separate process invocations**: `pfb spinner stop` (and `pfb wait-stop`)
+  now recover spinner state from a state file when `PFB_SPINNER_PID` is unset in the current
+  shell. Previously, calling `pfb spinner start` and `pfb spinner stop` as separate invocations
+  of the installed binary — rather than sourcing `pfb.sh` into one shell — left `stop` with no
+  way to see the exported PID, so it returned immediately without signaling the spinner loop to
+  exit. The loop, already disowned, kept running in the background indefinitely, leaking a
+  process and a `/tmp/pfb_spinner_*` flag file per invocation.
+
 ## [2.6.0] — 2026-07-20
 
 ### New Features

--- a/pfb.sh
+++ b/pfb.sh
@@ -15,6 +15,7 @@ export PFB_SPINNER_LABEL="wait"
 export PFB_SPINNER_PID=""
 export PFB_SPINNER_FLAG=""
 export PFB_SPINNER_ROW=""
+export PFB_SPINNER_STATE_FILE="${TMPDIR:-/tmp}/.pfb_spinner_state"
 export PFB_PROGRESS_ROW=""
 export PFB_PROGRESS_STYLE="0"
 
@@ -491,6 +492,14 @@ pfb() {
         PFB_SPINNER_PID=$!
         disown 2>/dev/null
 
+        # Persist state to disk. PFB_SPINNER_PID/_FLAG/_ROW only survive within
+        # this shell process; when `pfb spinner start` and `pfb spinner stop`
+        # run as separate invocations of the installed binary (rather than
+        # sourced into the same shell), `stop` has no way to see these
+        # exported vars. The state file lets it recover them.
+        printf '%s\n%s\n%s\n' "$PFB_SPINNER_PID" "$PFB_SPINNER_FLAG" "$PFB_SPINNER_ROW" \
+            > "$PFB_SPINNER_STATE_FILE" 2>/dev/null
+
         # Since there's no way to suppress the initial job control message
         # because `set +m`, using a subshell, and piping to /dev/null do
         # not work, move the cursor up to the initial job control message
@@ -502,28 +511,46 @@ pfb() {
 
     # Stop active spinner — MUST be synchronous
     _wait_stop() {
-        # Early exit if no spinner
-        [[ -z $PFB_SPINNER_PID ]] && return 0
+        local pid="$PFB_SPINNER_PID" flag="$PFB_SPINNER_FLAG" row="$PFB_SPINNER_ROW"
+
+        # Fall back to on-disk state when this process didn't start the
+        # spinner itself (see _wait_start for why the state file exists).
+        if [[ -z $pid && -f $PFB_SPINNER_STATE_FILE ]]; then
+            local state=()
+            mapfile -t state < "$PFB_SPINNER_STATE_FILE"
+            pid="${state[0]:-}"
+            flag="${state[1]:-}"
+            row="${state[2]:-}"
+        fi
+
+        # Early exit if no spinner, or its flag file is already gone (already stopped)
+        if [[ -z $pid ]] || { [[ -n $flag ]] && [[ ! -f $flag ]]; }; then
+            PFB_SPINNER_PID=""
+            PFB_SPINNER_FLAG=""
+            PFB_SPINNER_ROW=""
+            rm -f "$PFB_SPINNER_STATE_FILE" 2>/dev/null
+            return 0
+        fi
 
         # Remove flag file to signal stop
-        [[ -n $PFB_SPINNER_FLAG ]] && rm -f "$PFB_SPINNER_FLAG" 2>/dev/null
+        [[ -n $flag ]] && rm -f "$flag" 2>/dev/null
 
         # Wait for graceful exit (up to 0.5 seconds)
         local count=0
-        while kill -0 "$PFB_SPINNER_PID" 2>/dev/null && [[ $count -lt 10 ]]; do
+        while kill -0 "$pid" 2>/dev/null && [[ $count -lt 10 ]]; do
             sleep 0.05
             count=$((count + 1))
         done
 
         # Force kill if still running
-        if kill -0 "$PFB_SPINNER_PID" 2>/dev/null; then
-            kill -9 "$PFB_SPINNER_PID" 2>/dev/null
-            wait "$PFB_SPINNER_PID" 2>/dev/null
+        if kill -0 "$pid" 2>/dev/null; then
+            kill -9 "$pid" 2>/dev/null
+            wait "$pid" 2>/dev/null
         fi
 
         # Ensure line is cleared and cursor is on, using absolute row if available
-        if [[ -n "$PFB_SPINNER_ROW" ]]; then
-            cursor_to "$PFB_SPINNER_ROW"
+        if [[ -n "$row" ]]; then
+            cursor_to "$row"
             erase_line
         else
             erase_sol
@@ -535,6 +562,7 @@ pfb() {
         PFB_SPINNER_PID=""
         PFB_SPINNER_FLAG=""
         PFB_SPINNER_ROW=""
+        rm -f "$PFB_SPINNER_STATE_FILE" 2>/dev/null
 
         # Always return success
         return 0


### PR DESCRIPTION
## Summary

- `pfb spinner stop` (and the `pfb wait-stop` alias) only worked correctly when `pfb.sh` was sourced into the same shell process as `pfb spinner start`. Called as separate invocations of the installed binary — the normal case when pfb is on `PATH` — `PFB_SPINNER_PID` is always empty in the `stop` process, so it returned immediately without removing the flag file.
- The spinner loop, already `disown`ed by `start`, kept running in the background indefinitely: a leaked process plus a `/tmp/pfb_spinner_*` flag file per invocation.
- Reproduced against the current `main` (`pfb spinner start` + `pfb spinner stop` as two separate `pfb.sh` invocations leaves a live background process and a stale flag file); confirmed the fix eliminates both.
- Fix: `_wait_start` now also persists PID/flag/row to a small state file (`PFB_SPINNER_STATE_FILE`); `_wait_stop` falls back to reading it when the exported vars are empty in its own process. If the referenced flag file is already gone, it's treated as already-stopped rather than risking a stale/reused PID.
- Verified sourced start/stop and the `wait`/`wait-stop` backward-compat aliases still behave as before.

## Test plan

- [x] `./pfb.sh spinner start "..."` then `./pfb.sh spinner stop` as two separate process invocations: no leftover `/tmp/pfb_spinner_*` file, no leftover background process
- [x] Reproduced the bug on pre-fix `pfb.sh` for contrast (leftover flag file + live background process)
- [x] `source ./pfb.sh && pfb spinner start ... && pfb spinner stop` (single-process/sourced path) still works
- [x] `pfb wait` / `pfb wait-stop` backward-compat aliases still route through the same fixed functions
- [x] `bash -n pfb.sh` syntax check
- [x] `markdownlint CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)